### PR TITLE
Fix "undefined reference to `OctoSK6812::pixelBits'" error when compiling with Arduino

### DIFF
--- a/OctoSK6812.cpp
+++ b/OctoSK6812.cpp
@@ -30,6 +30,7 @@
 
 
 uint16_t OctoSK6812::stripLen;
+uint8_t OctoSK6812::pixelBits;
 void * OctoSK6812::frameBuffer;
 void * OctoSK6812::drawBuffer;
 uint8_t OctoSK6812::params;


### PR DESCRIPTION
I needed to add this line to get the examples to build in my installation.